### PR TITLE
Update github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,8 @@ jobs:
           - ubuntu-latest
           - windows-latest
         ocaml-version:
-          - 4.12.0
-          - 4.11.2
+          - 4.14.x
+          - 4.11.x
 
     runs-on: ${{ matrix.os }}
 
@@ -26,12 +26,11 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Use OCaml ${{ matrix.ocaml-version }}
-        uses: avsm/setup-ocaml@v1
+        uses: ocaml/setup-ocaml@v2
         with:
-          ocaml-version: ${{ matrix.ocaml-version }}
-
-      - run: opam pin add ppx_defer.dev -n .
-      - run: opam depext -yt ppx_defer
-      - run: opam install -t . --deps-only
-      - run: opam exec -- dune build
+          ocaml-compiler: ${{ matrix.ocaml-version }}
+          dune-cache: ${{ matrix.os != 'macos-latest' }}
+          opam-depext: true
+          opam-depext-flags: --with-test
+      - run: opam install . --deps-only --with-test
       - run: opam exec -- dune runtest


### PR DESCRIPTION
Switch to using the official ocaml github action plugin, and updates the build matrix to test ocaml 4.14 and 4.11. Testing on the lowest and the highest version of the compiler that's supported seemed okay for now.